### PR TITLE
python 3.10 related: import from "collections.abc" instead "collections"

### DIFF
--- a/gluster/gfapi/gfapi.py
+++ b/gluster/gfapi/gfapi.py
@@ -18,7 +18,7 @@ import time
 import stat
 import errno
 import uuid
-from collections import Iterator
+from collections.abc import Iterator
 
 from gluster.gfapi import api
 from gluster.gfapi.exceptions import LibgfapiException, Error

--- a/gluster/gfapi/gfapi.py
+++ b/gluster/gfapi/gfapi.py
@@ -18,7 +18,12 @@ import time
 import stat
 import errno
 import uuid
-from collections.abc import Iterator
+
+PY3_3 = sys.version_info >= (3, 3)
+if PY3_3:
+    from collections.abc import Iterator
+else:
+    from collections import Iterator
 
 from gluster.gfapi import api
 from gluster.gfapi.exceptions import LibgfapiException, Error


### PR DESCRIPTION
Iterator import in python console:
```python
Python 3.9.9 (main, Dec 21 2021, 10:35:05)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Iterator
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
>>>

Python 3.10.1 (main, Dec 21 2021, 09:50:13) [GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Iterator
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'Iterator' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
>>> from collections.abc import Iterator
>>>
```

gfapi import in python 3.10 console
```python
Python 3.10.1 (main, Dec 21 2021, 09:50:13) [GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from gluster import gfapi
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/site-packages/gluster/gfapi/__init__.py", line 13, in <module>
    from .gfapi import File, Dir, DirEntry, Volume
  File "/usr/local/lib/python3.10/site-packages/gluster/gfapi/gfapi.py", line 21, in <module>
    from collections import Iterator
ImportError: cannot import name 'Iterator' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
```